### PR TITLE
#25 #26 アカウント設定の改善

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     # 新規登録時にnameを許可
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    devise_parameter_sanitizer.permit(:sign_up, keys: %i[name avatar])
     # アカウント更新時にname・bio・avatarを許可
     devise_parameter_sanitizer.permit(:account_update, keys: %i[name bio avatar])
   end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Users
+  class RegistrationsController < Devise::RegistrationsController
+    # #25 admin アカウントは削除不可
+    def destroy
+      if current_user.admin?
+        redirect_to mypage_path, danger: '管理者アカウントは削除できません'
+        return
+      end
+
+      super
+    end
+
+    protected
+
+    # #26 画像未選択で保存した場合に既存アバターを保持する
+    def update_resource(resource, params)
+      params.delete(:avatar) if params[:avatar].blank?
+      super
+    end
+  end
+end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -21,24 +21,38 @@
         <%# アバター %>
         <div class="mb-6 flex flex-col items-center gap-3">
           <% if resource.avatar.attached? %>
-            <%= image_tag resource.avatar.url,
-                class: "w-20 h-20 rounded-full object-cover border-2",
-                style: "border-color: #d4a574; width: 80px; height: 80px;" %>
+            <img id="edit_avatar_preview" src="<%= resource.avatar.url %>"
+                 class="rounded-full object-cover border-2"
+                 style="width: 80px; height: 80px; border-color: #d4a574;">
           <% else %>
-            <div class="w-20 h-20 rounded-full flex items-center justify-center border-2"
+            <div id="edit_avatar_placeholder" class="w-20 h-20 rounded-full flex items-center justify-center border-2"
                  style="background-color: #f5f0eb; border-color: #d4a574;">
               <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" style="color: #d4a574;">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
               </svg>
             </div>
+            <img id="edit_avatar_preview" src="" alt="" style="display: none; width: 80px; height: 80px; border-color: #d4a574;"
+                 class="rounded-full object-cover border-2">
           <% end %>
           <div>
             <%= f.label :avatar, "アイコン画像を変更", class: "block text-xs font-medium mb-1", style: "color: #8b7355;" %>
-            <%= f.file_field :avatar, accept: "image/*",
+            <%= f.file_field :avatar, accept: "image/*", id: "edit_avatar_input",
                 class: "block text-xs",
                 style: "color: #8b7355;" %>
           </div>
         </div>
+        <script>
+          document.getElementById('edit_avatar_input').addEventListener('change', function(e) {
+            var file = e.target.files[0];
+            var preview = document.getElementById('edit_avatar_preview');
+            var placeholder = document.getElementById('edit_avatar_placeholder');
+            if (file && file.type.startsWith('image/')) {
+              preview.src = URL.createObjectURL(file);
+              preview.style.display = 'block';
+              if (placeholder) placeholder.style.display = 'none';
+            }
+          });
+        </script>
 
         <%# 名前 %>
         <div class="mb-5">
@@ -90,27 +104,36 @@
         </div>
 
         <%# 現在のパスワード（必須） %>
-        <div class="mb-6 p-4 rounded-lg" style="background-color: #faf6f2; border: 1px solid #e8d5c4;">
+        <div id="current_password_wrapper" class="mb-6 p-4 rounded-lg" style="background-color: #faf6f2; border: 1px solid #e8d5c4;">
           <%= f.label :current_password, "現在のパスワード（変更を保存するために必要）", class: "block text-sm font-medium mb-1", style: "color: #471e0a;" %>
-          <%= f.password_field :current_password, autocomplete: "current-password",
+          <%= f.password_field :current_password, id: "current_password_field", autocomplete: "current-password",
               class: "w-full px-3 py-2 rounded-md border text-sm focus:outline-none",
               style: "border-color: #d4a574; color: #471e0a;" %>
+          <p id="current_password_error" class="text-xs mt-1" style="color: #dc2626; display: none;">現在のパスワードを入力してください</p>
         </div>
 
-        <%= f.submit "保存する",
+        <%= f.submit "保存する", id: "profile_submit",
             class: "w-full py-2.5 text-sm font-medium text-white rounded-md cursor-pointer transition",
             style: "background-color: #b8854a;" %>
       <% end %>
+
+      <script>
+        document.getElementById('profile_submit').addEventListener('click', function(e) {
+          var passwordField = document.getElementById('current_password_field');
+          var errorMsg = document.getElementById('current_password_error');
+          var wrapper = document.getElementById('current_password_wrapper');
+          if (passwordField.value.trim() === '') {
+            e.preventDefault();
+            errorMsg.style.display = 'block';
+            wrapper.style.border = '1px solid #dc2626';
+            passwordField.focus();
+          } else {
+            errorMsg.style.display = 'none';
+            wrapper.style.border = '1px solid #e8d5c4';
+          }
+        });
+      </script>
     </div>
 
-    <%# アカウント削除 %>
-    <div class="mt-6 text-center">
-      <%= button_to "アカウントを削除する", registration_path(resource_name),
-          data: { turbo_confirm: "本当にアカウントを削除しますか？この操作は取り消せません。" },
-          method: :delete,
-          class: "text-xs",
-          style: "color: #a89080; background: none; border: none; cursor: pointer;" %>
-    </div>
-
-  </div>
+</div>
 </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -19,8 +19,38 @@
 
       <!-- カードコンテンツ -->
       <div class="px-6 pt-2 pb-6">
-        <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "space-y-4", novalidate: true }) do |f| %>
+        <%= form_for(resource, as: resource_name, url: registration_path(resource_name),
+              html: { class: "space-y-4", novalidate: true, enctype: "multipart/form-data" }) do |f| %>
           <%= render "devise/shared/error_messages", resource: resource %>
+
+          <!-- アイコン画像（任意） -->
+          <div class="space-y-2">
+            <%= f.label :avatar, "アイコン画像（任意）", class: "block text-sm font-medium", style: "color: #8b7355;" %>
+            <div class="flex flex-col items-center gap-3">
+              <div id="avatar_preview_wrapper" style="display: none;">
+                <img id="avatar_preview" src="" alt="プレビュー"
+                     class="rounded-full object-cover border-2"
+                     style="width: 72px; height: 72px; border-color: #d4a574;">
+              </div>
+              <%= f.file_field :avatar, accept: "image/*", id: "avatar_input",
+                  class: "w-full text-xs",
+                  style: "color: #8b7355;" %>
+            </div>
+            <script>
+              document.getElementById('avatar_input').addEventListener('change', function(e) {
+                var file = e.target.files[0];
+                var wrapper = document.getElementById('avatar_preview_wrapper');
+                var preview = document.getElementById('avatar_preview');
+                if (file && file.type.startsWith('image/')) {
+                  preview.src = URL.createObjectURL(file);
+                  wrapper.style.display = 'block';
+                } else {
+                  wrapper.style.display = 'none';
+                  preview.src = '';
+                }
+              });
+            </script>
+          </div>
 
           <!-- お名前 -->
           <div class="space-y-2">

--- a/app/views/users/mypage.html.erb
+++ b/app/views/users/mypage.html.erb
@@ -176,5 +176,22 @@
       <% end %>
     </section>
 
+    <% unless current_user.admin? %>
+      <%# 危険ゾーン: アカウント削除 %>
+      <div class="mt-12 border rounded-xl p-6" style="border-color: #dc2626; background-color: #fff5f5;">
+        <h2 class="text-base font-semibold mb-1" style="color: #dc2626;">危険ゾーン</h2>
+        <p class="text-sm mb-4" style="color: #6b5744;">
+          アカウントを削除すると、投稿した銘菓・コメント・お気に入りがすべて削除されます。この操作は取り消せません。
+        </p>
+        <%= button_to user_registration_path,
+            method: :delete,
+            data: { turbo_confirm: "本当にアカウントを削除しますか？\n投稿・コメント・お気に入りがすべて削除されます。この操作は取り消せません。" },
+            class: "px-4 py-2 text-sm font-medium text-white rounded-md border-0 cursor-pointer",
+            style: "background-color: #dc2626;" do %>
+          アカウントを削除する
+        <% end %>
+      </div>
+    <% end %>
+
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,15 +1,17 @@
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
   namespace :admin do
-    root 'dashboard#index'  # 管理画面のトップページ
-    resources :users, only: [:index, :edit, :update, :destroy]
-    resources :specialties, only: [:index, :edit, :update, :destroy]
+    root 'dashboard#index' # 管理画面のトップページ
+    resources :users, only: %i[index edit update destroy]
+    resources :specialties, only: %i[index edit update destroy]
   end
   # Devise（ユーザー認証）
-  devise_for :users
-  
+  devise_for :users, controllers: { registrations: 'users/registrations' }
+
   # ルートページ
   root 'home#index'
-  
+
   # Specialties（銘菓）の全アクション
   resources :specialties do
     resources :comments, only: %i[create destroy]
@@ -29,10 +31,10 @@ Rails.application.routes.draw do
   get 'terms', to: 'pages#terms'
   get 'privacy', to: 'pages#privacy'
   get 'guide', to: 'pages#guide', as: :guide
-  
+
   # ヘルスチェック（本番環境で必要な場合）
   # get "up" => "rails/health#show", as: :rails_health_check
-  
+
   # PWA機能（Progressive Web App用）
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest


### PR DESCRIPTION
- カスタム RegistrationsController を追加
  - admin アカウントの削除を禁止 (#25)
  - プロフィール編集時に画像未選択なら既存アバターを保持 (#26)
- 新規登録フォームにアバター選択＋プレビュー追加 (#26)
- プロフィール編集フォームに画像変更プレビュー追加 (#26)
- プロフィール編集でパスワード未入力時にクライアントサイドでブロック (#26)
- マイページ最下部に危険ゾーン（アカウント削除）セクション追加 (#25)
- プロフィール編集画面のアカウント削除リンクを削除 (#25)

fix #25
fix #26 