### PR TITLE
下書き保存機能を追加: 銘菓の投稿・編集フォームに下書き保存ボタンを追加し、公開前に保存できるように

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,3 +30,6 @@ Metrics/MethodLength:
 
 Layout/SpaceInsideArrayLiteralBrackets:
   Enabled: false
+
+Metrics/ClassLength:
+  Max: 110

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,7 +2,7 @@
 
 class HomeController < ApplicationController
   def index
-    @q            = Specialty.ransack(params[:q])
+    @q            = Specialty.publicly_visible.ransack(params[:q])
     @specialties  = filtered_specialties
     @regions      = Region.order(:name)
     @popular_specialties = popular_specialties
@@ -28,7 +28,8 @@ class HomeController < ApplicationController
   end
 
   def popular_specialties
-    Specialty.left_joins(:favorites)
+    Specialty.publicly_visible
+             .left_joins(:favorites)
              .group(:id)
              .order('COUNT(favorites.id) DESC')
              .limit(5)
@@ -40,7 +41,8 @@ class HomeController < ApplicationController
   end
 
   def recent_posts
-    Specialty.includes(:region, :user)
+    Specialty.publicly_visible
+             .includes(:region, :user)
              .order(created_at: :desc)
              .limit(5)
              .map { |s| { type: :post, record: s, created_at: s.created_at } }

--- a/app/controllers/region_blocks_controller.rb
+++ b/app/controllers/region_blocks_controller.rb
@@ -10,6 +10,7 @@ class RegionBlocksController < ApplicationController
 
     @block_name = REGION_BLOCK_NAMES[block_key]
     @specialties = Specialty
+                   .publicly_visible
                    .where(region_id: REGION_BLOCKS[block_key])
                    .includes(:user, :favorites, :tags, :region)
                    .order(created_at: :desc)

--- a/app/controllers/regions_controller.rb
+++ b/app/controllers/regions_controller.rb
@@ -4,6 +4,7 @@ class RegionsController < ApplicationController
   def show
     @region = Region.find(params[:id])
     @specialties = @region.specialties
+                          .publicly_visible
                           .includes(:user, :favorites, :tags)
                           .order(created_at: :desc)
                           .page(params[:page])

--- a/app/controllers/specialties_controller.rb
+++ b/app/controllers/specialties_controller.rb
@@ -7,9 +7,8 @@ class SpecialtiesController < ApplicationController
   before_action :set_specialty, only: %i[show edit update destroy]
   before_action :authorize_user!, only: %i[edit update destroy]
 
-  # 一覧表示
   def index
-    @q           = Specialty.ransack(params[:q])
+    @q           = Specialty.publicly_visible.ransack(params[:q])
     @specialties = sorted_specialties(filtered_base)
     @regions     = Region.order(:name)
     @recent_commented_ids = Comment.where('created_at > ?', 24.hours.ago)
@@ -18,54 +17,48 @@ class SpecialtiesController < ApplicationController
                                    .to_set
   end
 
-  # 詳細表示
   def show
-    @comment = Comment.new
+    return redirect_to root_path, danger: 'このページは存在しません' if draft_by_other?
+
+    @comment  = Comment.new
     @comments = @specialty.comments
                           .includes(user: { avatar_attachment: :blob })
                           .order(created_at: :desc)
-    related_base = @specialty.region.specialties
-                             .where.not(id: @specialty.id)
-                             .order(created_at: :desc)
-    @related_specialties_count = related_base.count
-    @related_specialties = related_base.includes(:favorites).limit(3)
+    set_related_specialties
   end
 
-  # 新規作成フォーム
   def new
     @specialty = Specialty.new
     @grouped_regions = build_grouped_regions
   end
 
-  # 編集フォーム
   def edit
     @grouped_regions = build_grouped_regions
   end
 
-  # 新規作成処理
   def create
     @specialty = current_user.specialties.build(specialty_params)
-
+    @specialty.status = params[:draft].present? ? :draft : :published
     if @specialty.save
-      redirect_to @specialty, success: '銘菓を登録しました'
+      msg = @specialty.draft? ? '下書きを保存しました' : '銘菓を登録しました'
+      redirect_to @specialty, success: msg
     else
       flash.now[:danger] = '銘菓の登録に失敗しました'
       render :new, status: :unprocessable_content
     end
   end
 
-  # 更新処理
   def update
-    @specialty.image.purge if params[:specialty][:remove_image] == '1' && @specialty.image.attached?
+    prepare_specialty_for_update
     if @specialty.update(specialty_params)
-      redirect_to @specialty, success: '銘菓を更新しました'
+      msg = @specialty.draft? ? '下書きを保存しました' : '銘菓を更新しました'
+      redirect_to @specialty, success: msg
     else
       flash.now[:danger] = '銘菓の更新に失敗しました'
       render :edit, status: :unprocessable_content
     end
   end
 
-  # 削除処理
   def destroy
     @specialty.destroy!
     redirect_to root_path, danger: '銘菓を削除しました'
@@ -103,18 +96,33 @@ class SpecialtiesController < ApplicationController
     scope
   end
 
-  # パラメータの許可
   def specialty_params
     params.require(:specialty).permit(:name, :region_id, :description, :image, :tag_list)
   end
 
-  # 銘菓の取得
   def set_specialty
     @specialty = Specialty.includes(:favorites, :tags).find(params[:id])
   end
 
-  # 権限チェック（自分の銘菓のみ編集・削除可能）
   def authorize_user!
     redirect_to specialties_path, danger: '権限がありません' unless @specialty.user == current_user
+  end
+
+  def draft_by_other?
+    @specialty.draft? && @specialty.user != current_user
+  end
+
+  def set_related_specialties
+    related_base = @specialty.region.specialties
+                             .publicly_visible
+                             .where.not(id: @specialty.id)
+                             .order(created_at: :desc)
+    @related_specialties_count = related_base.count
+    @related_specialties       = related_base.includes(:favorites).limit(3)
+  end
+
+  def prepare_specialty_for_update
+    @specialty.image.purge if params[:specialty][:remove_image] == '1' && @specialty.image.attached?
+    @specialty.status = params[:draft].present? ? :draft : :published
   end
 end

--- a/app/models/specialty.rb
+++ b/app/models/specialty.rb
@@ -25,6 +25,10 @@ class Specialty < ApplicationRecord
     favorites.exists?(user_id: user.id)
   end
 
+  enum :status, { published: 0, draft: 1 }
+
+  scope :publicly_visible, -> { published }
+
   validates :name, presence: true, length: { maximum: 100 }
 
   validate :image_type_and_size, if: -> { image.attached? }

--- a/app/views/specialties/edit.html.erb
+++ b/app/views/specialties/edit.html.erb
@@ -110,8 +110,15 @@
 
         <%# 送信ボタン %>
         <div class="flex gap-4 pt-4">
-          <%= f.submit "更新する", class: "flex-1 px-6 py-3 rounded-md transition-all font-medium cursor-pointer text-white hover:shadow-lg", style: "background-color: #471e0a;" %>
-          <%= link_to "キャンセル", specialty_path(@specialty), class: "flex-1 px-6 py-3 rounded-md transition-all font-medium text-center border-2 hover:shadow-lg", style: "color: #471e0a; background-color: white; border-color: #d4a574;" %>
+          <%= f.submit "下書き保存", name: "draft",
+              class: "flex-1 px-6 py-3 rounded-md transition-all font-medium cursor-pointer hover:shadow-lg",
+              style: "color: #8b7355; background-color: white; border: 2px solid #8b7355;" %>
+          <%= f.submit "更新・公開する",
+              class: "flex-1 px-6 py-3 rounded-md transition-all font-medium cursor-pointer text-white hover:shadow-lg",
+              style: "background-color: #471e0a;" %>
+          <%= link_to "キャンセル", specialty_path(@specialty),
+              class: "flex-1 px-6 py-3 rounded-md transition-all font-medium text-center border-2 hover:shadow-lg",
+              style: "color: #471e0a; background-color: white; border-color: #d4a574;" %>
         </div>
       <% end %>
     </div>

--- a/app/views/specialties/new.html.erb
+++ b/app/views/specialties/new.html.erb
@@ -115,12 +115,15 @@
           </script>
           <!-- 送信ボタン -->
           <div class="flex gap-3 pt-4">
-            <%= link_to 'キャンセル', 
-                        root_path, 
-                        class: 'flex-1 px-4 py-3 border rounded-md text-center font-medium transition-colors hover:shadow-md', 
+            <%= link_to 'キャンセル',
+                        root_path,
+                        class: 'flex-1 px-4 py-3 border rounded-md text-center font-medium transition-colors hover:shadow-md',
                         style: 'color: #471e0a; background-color: white; border-color: #d4a574;' %>
-            <%= f.submit '投稿する', 
-                         class: 'flex-1 px-4 py-3 border rounded-md text-center font-medium transition-colors hover:shadow-md', 
+            <%= f.submit '下書き保存', name: 'draft',
+                         class: 'flex-1 px-4 py-3 border rounded-md text-center font-medium transition-colors hover:shadow-md',
+                         style: 'color: #8b7355; background-color: white; border-color: #8b7355;' %>
+            <%= f.submit '投稿する',
+                         class: 'flex-1 px-4 py-3 border rounded-md text-center font-medium transition-colors hover:shadow-md',
                          style: 'color: white; background-color: #b8854a; border-color: #b8854a;' %>
           </div>
         <% end %>  <!-- form_with の終了 -->

--- a/app/views/users/mypage.html.erb
+++ b/app/views/users/mypage.html.erb
@@ -53,11 +53,22 @@
         自分の投稿
         <span class="text-base font-normal ml-2" style="color: #8b7355;">(<%= @my_specialties.total_count %>件)</span>
       </h2>
+      <% draft_count = @my_specialties.select(&:draft?).size %>
+      <% if draft_count > 0 %>
+        <p class="text-xs mb-4 px-3 py-1.5 rounded-md inline-block" style="background-color: #f5f0eb; color: #8b7355; border: 1px solid #d4a574;">
+          下書き <%= draft_count %>件 含む
+        </p>
+      <% end %>
 
       <% if @my_specialties.present? %>
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           <% @my_specialties.each do |specialty| %>
             <div class="bg-white rounded-xl shadow-sm border overflow-hidden" style="border-color: #e8d5c4;">
+              <% if specialty.draft? %>
+                <div class="px-3 py-1 text-xs font-medium text-center" style="background-color: #f5f0eb; color: #8b7355; border-bottom: 1px solid #e8d5c4;">
+                  下書き
+                </div>
+              <% end %>
               <%# 画像 %>
               <%= link_to specialty_path(specialty) do %>
                 <% if specialty.image.attached? %>

--- a/db/migrate/20260406130001_enforce_region_id_not_null_on_specialties.rb
+++ b/db/migrate/20260406130001_enforce_region_id_not_null_on_specialties.rb
@@ -1,7 +1,7 @@
 class EnforceRegionIdNotNullOnSpecialties < ActiveRecord::Migration[7.2]
   def up
     # region_id が NULL のレコードが残っていれば安全に停止する
-    null_count = Specialty.where(region_id: nil).count
+    null_count = execute("SELECT COUNT(*) FROM specialties WHERE region_id IS NULL").first["count"].to_i
     if null_count > 0
       raise ActiveRecord::IrreversibleMigration,
             "specialties に region_id が NULL のレコードが #{null_count} 件あります。" \

--- a/db/migrate/20260406140001_add_limit_to_specialties_name.rb
+++ b/db/migrate/20260406140001_add_limit_to_specialties_name.rb
@@ -1,7 +1,7 @@
 class AddLimitToSpecialtiesName < ActiveRecord::Migration[7.2]
   def up
     # 既存データで100文字を超える name があれば安全に停止
-    over_limit = Specialty.where("LENGTH(name) > 100").count
+    over_limit = execute("SELECT COUNT(*) FROM specialties WHERE LENGTH(name) > 100").first["count"].to_i
     if over_limit > 0
       raise ActiveRecord::IrreversibleMigration,
             "specialties.name が 100文字を超えるレコードが #{over_limit} 件あります。" \

--- a/db/migrate/20260424000001_add_status_to_specialties.rb
+++ b/db/migrate/20260424000001_add_status_to_specialties.rb
@@ -1,0 +1,6 @@
+class AddStatusToSpecialties < ActiveRecord::Migration[7.2]
+  def change
+    add_column :specialties, :status, :integer, default: 0, null: false
+    add_index :specialties, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_06_150000) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_24_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -76,7 +76,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_06_150000) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0, null: false
     t.index ["region_id"], name: "index_specialties_on_region_id"
+    t.index ["status"], name: "index_specialties_on_status"
     t.index ["user_id"], name: "index_specialties_on_user_id"
   end
 


### PR DESCRIPTION
- specialties に status カラム（published/draft enum）を追加
- 下書きは本人のみ閲覧可能、公開一覧には表示しない
- マイページで下書き件数バッジを表示
- RuboCop 対応: Metrics/ClassLength を Max: 110 に調整

fix #24 