### PR TITLE
カードのタグをクリック可能なリンクにする

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -405,16 +405,18 @@
                   </p>
                 <% end %>
 
-                <%# タグ %>
-                <% if specialty.tags.any? %>
-                  <div class="flex flex-wrap gap-1 mt-2">
-                    <% specialty.tags.each do |tag| %>
-                      <span class="inline-block px-2 py-0.5 rounded-full text-xs"
-                            style="background-color: #f5ece0; color: #8b7355; border: 1px solid #e8d5c4;">
-                        #<%= tag.name %>
-                      </span>
-                    <% end %>
-                  </div>
+              </div>
+            <% end %>
+
+            <%# タグ（リンクの外） %>
+            <% if specialty.tags.any? %>
+              <div class="flex flex-wrap gap-1 px-4 pb-2">
+                <% specialty.tags.each do |tag| %>
+                  <%= link_to root_path(tag: tag.name),
+                      class: "inline-block px-2 py-0.5 rounded-full text-xs",
+                      style: "background-color: #f5ece0; color: #8b7355; border: 1px solid #e8d5c4;" do %>
+                    #<%= tag.name %>
+                  <% end %>
                 <% end %>
               </div>
             <% end %>

--- a/app/views/specialties/index.html.erb
+++ b/app/views/specialties/index.html.erb
@@ -124,16 +124,18 @@
                 </p>
               <% end %>
 
-              <%# タグ %>
-              <% if specialty.tags.any? %>
-                <div class="flex flex-wrap gap-1 mt-2">
-                  <% specialty.tags.each do |tag| %>
-                    <span class="inline-block px-2 py-0.5 rounded-full text-xs"
-                          style="background-color: #f5ece0; color: #8b7355; border: 1px solid #e8d5c4;">
-                      #<%= tag.name %>
-                    </span>
-                  <% end %>
-                </div>
+            </div>
+          <% end %>
+
+          <%# タグ（リンクの外） %>
+          <% if specialty.tags.any? %>
+            <div class="flex flex-wrap gap-1 px-4 pb-2">
+              <% specialty.tags.each do |tag| %>
+                <%= link_to specialties_path(tag: tag.name),
+                    class: "inline-block px-2 py-0.5 rounded-full text-xs",
+                    style: "background-color: #f5ece0; color: #8b7355; border: 1px solid #e8d5c4;" do %>
+                  #<%= tag.name %>
+                <% end %>
               <% end %>
             </div>
           <% end %>


### PR DESCRIPTION
トップページ・銘菓一覧のカードに表示されているタグを span から
link_to に変更し、クリックでタグ絞り込みができるようにした。
ネストを避けるため、タグをカードリンクの外に移動した。

fix #41 