### PR TITLE
スマホで検索バーが右にはみ出す問題を修正

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -348,8 +348,8 @@
         銘菓一覧
         <span class="text-lg ml-1 font-normal" style="color: #8b7355;">(<%= @specialties.total_count %>件)</span>
       </h2>
-      <div class="flex-1 flex justify-end">
-        <%= search_form_for @q, url: root_path, html: { class: "w-full", style: "max-width: 26rem;" } do |f| %>
+      <div class="flex-1 flex justify-end min-w-0">
+        <%= search_form_for @q, url: root_path, html: { class: "w-full sm:max-w-lg" } do |f| %>
           <div class="flex items-center" style="border: 1px solid #d4a574; border-radius: 9999px; background: white; overflow: hidden;">
             <%= f.search_field :name_cont,
                 placeholder: "銘菓名を検索...",


### PR DESCRIPTION
flex コンテナに min-w-0 を追加してはみ出しを防止し、
max-width をスマホでは解除・sm以上でのみ適用するよう変更。

fix #45 