### PR TITLE
画像アップロード欄にiPhoneユーザー向けヒントを追加する

### DIFF
--- a/app/views/specialties/edit.html.erb
+++ b/app/views/specialties/edit.html.erb
@@ -93,6 +93,7 @@
 
           <%= f.file_field :image, id: 'specialty_image_input', accept: "image/*", class: "w-full px-4 py-3 border rounded-md focus:outline-none focus:ring-2 focus:ring-amber-400 transition-all", style: "border-color: #d4a574;" %>
           <p class="text-xs mt-1" style="color: #a89080;">対応形式: JPG / JPEG / PNG（5MB以下）</p>
+          <p class="text-xs mt-1" style="color: #a89080;">iPhoneをお使いの場合は 設定 → カメラ → フォーマット → 互換性優先 に変更するとアップロードできます</p>
           <p class="text-sm mt-1" style="color: #6b5744;">ファイルを選択すると現在の画像が更新されます</p>
         </div>
         <script>

--- a/app/views/specialties/new.html.erb
+++ b/app/views/specialties/new.html.erb
@@ -86,6 +86,7 @@
                              style: 'border-color: #d4a574; color: #471e0a;',
                              accept: 'image/*' %>
             <p class="text-xs" style="color: #a89080;">対応形式: JPG / JPEG / PNG（5MB以下）</p>
+            <p class="text-xs" style="color: #a89080;">iPhoneをお使いの場合は 設定 → カメラ → フォーマット → 互換性優先 に変更するとアップロードできます</p>
             <!-- 画像プレビュー -->
             <div id="image_preview_wrapper" style="display: none;" class="mt-3">
               <p class="text-sm mb-2 font-medium" style="color: #6b5744;">選択した画像のプレビュー:</p>


### PR DESCRIPTION
iPhoneのHEIC形式はアップロード非対応のため、設定変更の案内を
新規投稿・編集フォームのファイル選択欄の下に追記した。