### PR TITLE
トップページの銘菓カード画像にinsetシャドウを追加する

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -390,7 +390,7 @@
             <%# 画像・内容エリア（銘菓詳細へのリンク） %>
             <%= link_to specialty_path(specialty), class: "block flex-1 flex flex-col" do %>
               <%# 画像表示部分 %>
-              <div class="aspect-video w-full bg-gray-100 overflow-hidden relative">
+              <div class="aspect-video w-full bg-gray-100 overflow-hidden relative" style="box-shadow: inset 0 -3px 8px rgba(0,0,0,0.06), inset 0 3px 8px rgba(0,0,0,0.06);">
                 <% if specialty.image.attached? %>
                   <%= image_tag specialty.image.variant(resize_to_fill: [400, 300]),
                       alt: specialty.name,


### PR DESCRIPTION
白背景の画像がカード背景と同化して境目が見えなくなる問題に対し、
画像コンテナの上下にごく薄いinsetシャドウを追加して自然に境目を見せる。

fix #55 