### PR TITLE
カードのタグ・いいね位置をカード下部に固定する

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -448,7 +448,7 @@
 
             <%# タグ（リンクの外） %>
             <% if specialty.tags.any? %>
-              <div class="flex flex-wrap gap-1 px-4 pb-2">
+              <div class="flex flex-wrap gap-1 px-4 pb-2 mt-auto">
                 <% specialty.tags.each do |tag| %>
                   <%= link_to root_path(tag: tag.name),
                       class: "inline-block px-2 py-0.5 rounded-full text-xs",

--- a/app/views/specialties/index.html.erb
+++ b/app/views/specialties/index.html.erb
@@ -129,7 +129,7 @@
 
           <%# タグ（リンクの外） %>
           <% if specialty.tags.any? %>
-            <div class="flex flex-wrap gap-1 px-4 pb-2">
+            <div class="flex flex-wrap gap-1 px-4 pb-2 mt-auto">
               <% specialty.tags.each do |tag| %>
                 <%= link_to specialties_path(tag: tag.name),
                     class: "inline-block px-2 py-0.5 rounded-full text-xs",


### PR DESCRIPTION
タグ数の違いによってカード内のいいね表示位置がずれる問題を修正。
home/index と specialties/index のタグ div に mt-auto を追加し、 タグとフッターを常にカード最下部に揃える。