### PR TITLE
ユーザー公開ページのカードいいね位置をカード下部に固定する

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -46,7 +46,7 @@
       <% if @specialties.present? %>
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           <% @specialties.each do |specialty| %>
-            <div class="bg-white rounded-xl shadow-sm border overflow-hidden" style="border-color: #e8d5c4;">
+            <div class="bg-white rounded-xl shadow-sm border overflow-hidden flex flex-col" style="border-color: #e8d5c4;">
               <%= link_to specialty_path(specialty) do %>
                 <% if specialty.image.attached? %>
                   <%= image_tag specialty.image.variant(resize_to_fill: [400, 300]),
@@ -60,18 +60,20 @@
                 <% end %>
               <% end %>
 
-              <div class="p-4">
-                <h3 class="text-base font-bold mb-1 truncate" style="color: #471e0a;">
-                  <%= link_to specialty.name, specialty_path(specialty), style: "color: #471e0a;" %>
-                </h3>
-                <div class="flex items-center text-xs mb-2" style="color: #6b5744;">
-                  <svg class="w-3.5 h-3.5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"/>
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"/>
-                  </svg>
-                  <%= specialty.region.name %>
+              <div class="p-4 flex-1 flex flex-col">
+                <div class="flex-1">
+                  <h3 class="text-base font-bold mb-1 truncate" style="color: #471e0a;">
+                    <%= link_to specialty.name, specialty_path(specialty), style: "color: #471e0a;" %>
+                  </h3>
+                  <div class="flex items-center text-xs mb-2" style="color: #6b5744;">
+                    <svg class="w-3.5 h-3.5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"/>
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"/>
+                    </svg>
+                    <%= specialty.region.name %>
+                  </div>
                 </div>
-                <div class="flex flex-wrap gap-1 mb-2">
+                <div class="flex flex-wrap gap-1 mb-2 mt-auto">
                   <% specialty.tags.each do |tag| %>
                     <span class="text-xs px-2 py-0.5 rounded-full" style="background-color: #f5ece0; color: #8b7355; border: 1px solid #d4a574;">#<%= tag.name %></span>
                   <% end %>


### PR DESCRIPTION
タグ数の違いによってカード内の♡位置がずれる問題を修正。
カードに flex flex-col を追加し、コンテンツ部分を flex-1 flex flex-col に変更。 タグ div に mt-auto を追加してタグ・いいねを常にカード最下部に揃える。