### PR TITLE
人気銘菓のいいね数取得でN+1クエリが発生していた問題を修正

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -33,7 +33,7 @@ class HomeController < ApplicationController
              .group(:id)
              .order('COUNT(favorites.id) DESC')
              .limit(5)
-             .includes(:region)
+             .includes(:region, :favorites)
   end
 
   def recent_activities


### PR DESCRIPTION
popular_specialties で :favorites が includes されていなかったため、 ビューで favorites.size を呼ぶたびに個別クエリが発生していた。
includes(:region, :favorites) に変更して一括取得するよう修正。