### PR TITLE
コメント投稿者のアイコン・名前からプロフィールページへのリンクを追加

### DIFF
--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -5,19 +5,23 @@
     <div class="flex items-start justify-between gap-4">
       <div class="flex-1">
         <div class="flex items-center gap-2 mb-1">
-          <% if comment.user.avatar.attached? %>
-            <%= image_tag comment.user.avatar.url,
-                class: "rounded-full object-cover flex-shrink-0",
-                style: "width: 28px; height: 28px;" %>
-          <% else %>
-            <div class="rounded-full flex items-center justify-center flex-shrink-0"
-                 style="width: 28px; height: 28px; background-color: #f5f0eb; border: 1px solid #d4a574;">
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" style="color: #d4a574;">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
-              </svg>
-            </div>
+          <%= link_to user_profile_path(comment.user) do %>
+            <% if comment.user.avatar.attached? %>
+              <%= image_tag comment.user.avatar.url,
+                  class: "rounded-full object-cover flex-shrink-0",
+                  style: "width: 28px; height: 28px;" %>
+            <% else %>
+              <div class="rounded-full flex items-center justify-center flex-shrink-0"
+                   style="width: 28px; height: 28px; background-color: #f5f0eb; border: 1px solid #d4a574;">
+                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" style="color: #d4a574;">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
+                </svg>
+              </div>
+            <% end %>
           <% end %>
-          <span class="text-sm font-medium" style="color: #471e0a;"><%= comment.user.name %></span>
+          <%= link_to comment.user.name, user_profile_path(comment.user),
+              class: "text-sm font-medium hover:underline",
+              style: "color: #471e0a;" %>
           <span class="text-xs" style="color: #a89080;"><%= l comment.created_at, format: :long %></span>
         </div>
         <p class="text-sm leading-relaxed whitespace-pre-wrap" style="color: #471e0a;"><%= comment.body %></p>


### PR DESCRIPTION
## 概要
コメント欄の投稿者アイコンと名前をクリックすると、そのユーザーのプロフィールページへ遷移できるようにした。

## 変更内容
- `app/views/comments/_comment.html.erb`
  - アイコン画像（またはデフォルトアイコン）を `link_to user_profile_path` でラップ
  - ユーザー名を `link_to` に変更し `hover:underline` を付与
