### PR TITLE
ホームページの銘菓画像N+1クエリを修正

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -18,7 +18,8 @@ class HomeController < ApplicationController
 
   def filtered_specialties
     scope = @q.result(distinct: true)
-              .includes({ user: { avatar_attachment: :blob } }, :region, :tags, :favorites, :comments)
+              .includes({ image_attachment: :blob }, { user: { avatar_attachment: :blob } },
+                        :region, :tags, :favorites, :comments)
               .order(created_at: :desc)
               .page(params[:page])
               .per(6)
@@ -33,7 +34,7 @@ class HomeController < ApplicationController
              .group(:id)
              .order('COUNT(favorites.id) DESC')
              .limit(5)
-             .includes(:region, :favorites)
+             .includes({ image_attachment: :blob }, :region, :favorites)
   end
 
   def recent_activities


### PR DESCRIPTION
銘菓一覧・人気ランキングでimage_attachment: :blobをincludesに追加し、 specialty.image.attached?のたびに発生していたクエリを解消する